### PR TITLE
Upgrade branch SNAPSHOT using TemplateControl

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,7 @@
-This software is licensed under the Apache 2 license, quoted below.
+License
+-------
+Written in 2016 by Lightbend <info@lightbend.com>
 
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this project except in compliance with
-the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide. This software is distributed without any warranty.
 
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
-language governing permissions and limitations under the License.
+You should have received a copy of the CC0 Public Domain Dedication along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.

--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.1"
 
-libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "1.6.0-SNAPSHOT" % Test
+libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "2.0.0-M2" % Test
 libraryDependencies += ws
 libraryDependencies += guice
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,4 +1,4 @@
 #Activator-generated Properties
 #Tue May 24 19:26:26 PDT 2016
 template.uuid=15c371e1-78e0-429a-84ff-11b1d09dd4a2
-sbt.version=0.13.11
+sbt.version=0.13.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,4 +3,4 @@ resolvers += Resolver.typesafeRepo("snapshots")
 resolvers += Resolver.jcenterRepo 
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.0-SNAPSHOT")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.0-M1")


### PR DESCRIPTION
```
Updated with template-control on 2017-02-17T23:40:54.461Z
  /LICENSE:
    wrote /LICENSE
  **/build.sbt:
    scalaVersion := "2.12.1"
  **/build.sbt:
    libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "2.0.0-M2" % Test
  **/build.properties:
    sbt.version=0.13.13
  **/plugins.sbt:
    addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.0-M1")

```
          