### PR TITLE
Play 2.6.1 CSRF NoTokenInBody Issue.

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -4,6 +4,7 @@
 
 GET     /                           controllers.HomeController.index
 
++ nocsrf
 POST    /upload                     controllers.HomeController.upload
 
 # Map static resources from the /public folder to the /assets URL path


### PR DESCRIPTION
[warn] p.filters.CSRF - [CSRF] Check failed because no or invalid token found in body
[warn] p.filters.CSRF - [CSRF] Check failed with NoTokenInBody