### PR TITLE
Update application.conf

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -3,3 +3,7 @@
 # Sets the maximum file size that can be uploaded to 1024k.
 # https://www.playframework.com/documentation/2.6.x/ScalaBodyParsers#Max-content-length
 play.http.parser.maxMemoryBuffer=1024k
+
+# For upload large file
+# https://www.playframework.com/documentation/2.6.x/ScalaBodyParsers#Max-content-length
+play.http.parser.maxDiskBuffer=1g


### PR DESCRIPTION
When I made the large file upload feature, I found that the maximum size of uploading file is set by 10M by default.
Of course, I know, Most people can find the content, if they cost a little time.
but I create a pull request for those who want to work as fast as possible like me, refering to the examples.